### PR TITLE
RFC: simplify elf output

### DIFF
--- a/seed/src/seed-linux-amd64.seed
+++ b/seed/src/seed-linux-amd64.seed
@@ -1699,15 +1699,7 @@ EFFECTS 20 + rcx mov_[aa],rr
 \ execute seed loop
 x' seedl jmp
 
-0 q,
-
 $ f_SizeInFile @ w!
-
-0 c,
-
-" .text" drop
-" .bss" drop
-" .shstrtab" drop
 
 ELF dump
 

--- a/seed/src/seed-linux-amd64.seed
+++ b/seed/src/seed-linux-amd64.seed
@@ -573,37 +573,38 @@ create ELF
 \ Extended ABI
 0 q,
 
-\ Executable file type
+\ e_type: Elf file type (ET_EXEC = 2)
 2 w,
 
-\ Target architecture x86_64
+\ e_machine: Target architecture (EM_X86_64 = 62 = 0x3e)
 3E w,
 
-\ Additional ELF version
+\ e_version
 1 d,
 
+\ e_entry: Entry point, lower 16 bits
 f_EntryPoint field
-
+\ and the remaining 48 bits; the virtual address is 0x001xxxx
 0 w, 1 w, 0 d,
 
+\ e_phoff: file offset of the program headers
 f_ProgramHeaders field
-
 0 q,
 
 f_SectionHeaders field
 
 0 q,
 
-\ Unused flags
+\ e_flags: unused
 0 d,
 
-\ Header size
+\ e_ehsize: size of this elf header (struct ELF64_Ehdr)
 40 w,
 
-\ Program header entry size
+\ e_phentsize: size of program header entry
 38 w,
 
-\ Number of program header entries
+\ e_phnum: Number of program header entries
 1 w,
 
 \ Section header entry size
@@ -615,32 +616,35 @@ f_SectionHeaders field
 \ Index of string table section
 3 w,
 
+\
 \ Program Headers
+\
 
 $ f_ProgramHeaders @ w!
 
-\ Program header type: 1 = loadable segment
+\ p_type: program header type (PT_LOAD = 1)
 1 d,
 
-\ Program header flags: 7 = read + write + execute
+\ p_flags: program header flags: 7 = read + write + execute
 7 d,
 
-\ Loadable segment offset in the file
+\ p_offset: loadable segment offset in the file
 0 q,
 
-\ Virtual address 10000
+\ p_vaddr: Virtual address, i.e. 10000
 0 w, 1 w, 0 d,
 
-\ Physical address ???
+\ p_paddr: Physical address (ignored)
 0 w, 1 w, 0 d,
 
+\ p_filesz: size in file
 f_SizeInFile field
 0 q,
 
-\ Size in memory
+\ p_memsz: size in memory
 0 w, 1 w, 0 d,
 
-\ Alignment
+\ p_align: alignment
 8000 q,
 
 \ Section Headers

--- a/seed/src/seed-linux-amd64.seed
+++ b/seed/src/seed-linux-amd64.seed
@@ -640,7 +640,7 @@ f_SizeInFile field
 0 w, 1 w, 0 d,
 
 \ p_align: alignment
-8000 q,
+1000 q,
 
 \
 \ Emit the machine code

--- a/seed/src/seed-linux-amd64.seed
+++ b/seed/src/seed-linux-amd64.seed
@@ -437,11 +437,7 @@ drop
 0 variable headersLength
 0 variable f_EntryPoint
 0 variable f_ProgramHeaders
-0 variable f_SectionHeaders
 0 variable f_SizeInFile
-0 variable f_TotalFileSize
-0 variable f_StringTableVA
-0 variable f_StringTableOffset
 
 {: 0c, 0 c, }
 
@@ -591,8 +587,7 @@ f_EntryPoint field
 f_ProgramHeaders field
 0 q,
 
-f_SectionHeaders field
-
+\ e_shoff: file offset of the section headers
 0 q,
 
 \ e_flags: unused
@@ -607,14 +602,14 @@ f_SectionHeaders field
 \ e_phnum: Number of program header entries
 1 w,
 
-\ Section header entry size
-40 w,
+\ e_shentsize: Section header entry size
+0 w,
 
-\ Number of section header entries
-4 w,
+\ e_shnum: Number of section header entries
+0 w,
 
-\ Index of string table section
-3 w,
+\ e_shstrndx: Index of string table section
+0 w,
 
 \
 \ Program Headers
@@ -647,99 +642,9 @@ f_SizeInFile field
 \ p_align: alignment
 8000 q,
 
-\ Section Headers
-
-$ f_SectionHeaders @ w!
-
-\ null header
-' 0c, 40 times
-
-\ .text segment
-
-\ Offset of .text in the table
-1 d,
-
-\ Loadable "bits" section
-1 d,
-
-\ Flags: 6 = allocated + executable
-6 q,
-
-\ Virtual address 10000
-0 w, 1 w, 0 d,
-
-\ Offset in the file
-0 q,
-
-f_TotalFileSize field
-0 q,
-
-\ Linked section index
-0 d,
-
-\ Info ???
-0 d,
-
-\ Alignment
-10 q,
-
-\ Section entry size
-0 q,
-
-\ .bss segment
-
-\ Offset of .bss in the table
-7 d,
-
-\ Type: nobits
-8 d,
-
-\ Flags: writable, allocated, executable
-7 q,
-
-\ Virtual address
-8000 w, 1 w, 0 d,
-
-\ Offset in the file
-0 q,
-
-\ Section size
-8000 q,
-
-\ Linked section index
-0 d,
-
-\ Info ???
-0 d,
-
-\ Alignment
-10 q,
-
-\ Section entry size
-0 q,
-
-
-
-\ String Table Section
-C d,
-
-\ Type: string table
-3 d,
-
-\ No need to load it
-0 q,
-
-f_StringTableVA field
-0 w, 1 w, 0 d,
-
-f_StringTableOffset field
-0 q,
-
-\ Length
-16 q,
-
-\ Other stuff
-0 d, 0 d, 1 q, 0 q,
+\
+\ Emit the machine code
+\
 
 $ f_EntryPoint @ w!
 
@@ -1796,18 +1701,13 @@ x' seedl jmp
 
 0 q,
 
-$ dup dup
-f_SizeInFile @ w!
-f_StringTableVA @ w!
-f_StringTableOffset @ w!
+$ f_SizeInFile @ w!
 
 0 c,
 
 " .text" drop
 " .bss" drop
 " .shstrtab" drop
-
-$ f_TotalFileSize @ w!
 
 ELF dump
 


### PR DESCRIPTION
the changes work fine, but i have only simplified seed, not sprout. should i simplify sprout, too?

section headers are ignored by the loader when the elf file is executed. it's only processed by tools like the linker, or parts of it are processed by the dynamic loader (`ld-linux.so`) when the binary is an `ET_DYN` (relocatable, ASLR-ready, requires dynamically linked shared objects, etc).

@nagydani please review the commits, because e.g. i didn't understand what this is when i deleted it:

```diff
1 file changed, 8 deletions(-)
seed/src/seed-linux-amd64.seed | 8 --------

modified   seed/src/seed-linux-amd64.seed
@@ -1737,16 +1737,8 @@ xcell+      rcx mov_[aa],rr
 \ execute seed loop
 x' seedl jmp
 
-0 q,
-
 $ f_SizeInFile @ w!
 
-0 c,
-
-" .text" drop
-" .bss" drop
-" .shstrtab" drop
-
 ELF dump
 
 bye
```

looks unnecessary, and it works fine, but still, i didn't understand why they were there.